### PR TITLE
CI: ubuntu-22.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   build:
     name: Build and Test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout current branch (full)
         uses: actions/checkout@v3
@@ -32,7 +32,7 @@ jobs:
   publish:
     name: Publish Artifacts
     needs: [ build ]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout current branch (full)
         uses: actions/checkout@v3


### PR DESCRIPTION
It's better to fix the version of Ubuntu in CI rather then it being `latest`.
The build will be more stable over the years.